### PR TITLE
Revert "Bump typescript from 4.5.5 to 4.6.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
     "typedoc": "^0.22.12",
-    "typescript": "~4.6.2"
+    "typescript": "~4.5.0"
   }
 }


### PR DESCRIPTION
Typedoc does not yet support 4.6

Reverts imretro/typescript-template#3